### PR TITLE
fix multiple titles: Use first title

### DIFF
--- a/tools/data/xql/getSource.xql
+++ b/tools/data/xql/getSource.xql
@@ -59,7 +59,7 @@ let $work := $expression/ancestor::mei:work[1]:)
 
  
 return (
-    concat('this.setName("', replace($source/mei:titleStmt/data(mei:title), '"', '\\"'), '");'),
+    concat('this.setName("', replace($source/mei:titleStmt/mei:title[1], '"', '\\"'), '");'),
     concat('this.setSignature("', replace($source/data(mei:identifier[@type eq 'siglum']), '"', '\\"'), '");'),
     concat('this.setComposer("', replace($source//mei:fileDesc/mei:titleStmt/mei:respStmt/data(mei:persName[@role eq 'composer']), '"', '\\"'), '");'),
     string('this.setWorkName("Work");'),


### PR DESCRIPTION
If a source would have multiple mei:title elements in its mei:titleStmt
the app would fail loading the source.

With this commit the first title will be evaluated.