### PR TITLE
Update outdated syntax (exist 5.x)

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -61,7 +61,7 @@ declare function local:set-user() as element()* {
             ()
 };
 
-declare function local:logout() as empty() {
+declare function local:logout() {
     session:clear()
 };
 

--- a/controller.xql
+++ b/controller.xql
@@ -66,11 +66,11 @@ declare function local:logout() as empty() {
 };
 
 let $exist-vars := map {
-   'path' := $exist:path,
-   'resource' := $exist:resource,
-   'controller' := $exist:controller,
-   'prefix' := $exist:prefix,
-   'root' := $exist:root
+   'path' : $exist:path,
+   'resource' : $exist:resource,
+   'controller' : $exist:controller,
+   'prefix' : $exist:prefix,
+   'root' : $exist:root
 }
 let $log := util:log-system-out($exist:prefix)
 

--- a/modules/view.xql
+++ b/modules/view.xql
@@ -22,8 +22,8 @@ declare option output:method "html5";
 declare option output:media-type "text/html";
 
 let $config := map {
-    $templates:CONFIG_APP_ROOT := $config:app-root,
-    $templates:CONFIG_STOP_ON_ERROR := true()
+    $templates:CONFIG_APP_ROOT : $config:app-root,
+    $templates:CONFIG_STOP_ON_ERROR : true()
 }
 (:
  : We have to provide a lookup function to templates:apply to help it


### PR DESCRIPTION
- replacing `:=` with `:` inside maps
- removing function output `as empty()`